### PR TITLE
Adding StartTimeout feature to TimeoutObservingStream & Unit Tests

### DIFF
--- a/QuickTest/TestThrottleStream.cs
+++ b/QuickTest/TestThrottleStream.cs
@@ -19,9 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 
-using Duplicati.StreamUtil;
-
-namespace QuickTest;
+namespace Duplicati.StreamUtil.QuickTest;
 
 public static class TestThrottleStream
 {

--- a/QuickTest/TestTimeoutStream.cs
+++ b/QuickTest/TestTimeoutStream.cs
@@ -20,7 +20,6 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System.Net;
-using Duplicati.StreamUtil;
 
 namespace Duplicati.StreamUtil.QuickTest;
 


### PR DESCRIPTION
The StartTimeout is a feature to trigger the cancelation if no read or write operation is completed before it elapses. Once elapsed, it is disabled. It can work in conjunction with read and write timeouts.

Minor: Also fixed namespace error.
